### PR TITLE
[AWS] Update default EMR and method for passing in spark env vars

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.8.2

--- a/src/main/scala/org/broadinstitute/dig/aws/emr/ReleaseLabel.scala
+++ b/src/main/scala/org/broadinstitute/dig/aws/emr/ReleaseLabel.scala
@@ -11,8 +11,8 @@ final case class ReleaseLabel(value: String) {
 object ReleaseLabel {
 
   /** Default EMR instance release version. */
-  val emrDefault: ReleaseLabel = ReleaseLabel("emr-5.30.0")
+  val emrDefault: ReleaseLabel = ReleaseLabel("emr-6.7.0")
 
   /** The latest EMR instance release version. */
-  val emrLatest: ReleaseLabel = ReleaseLabel("emr-6.0.0")
+  val emrLatest: ReleaseLabel = ReleaseLabel("emr-7.0.0")
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.1-SNAPSHOT"
+version in ThisBuild := "0.3.2-SNAPSHOT"


### PR DESCRIPTION
It was simpler to merely create two tracks which added the hadoop (script) and spark env vars separately. I also took the opportunity to update the default EMR image. The release should smooth out whatever issues that might cause as it fails fast and is pretty easy to solve.