### PR TITLE
[AWS] Add project to AWSConfig

### DIFF
--- a/src/main/scala/org/broadinstitute/dig/aws/config/AwsConfig.scala
+++ b/src/main/scala/org/broadinstitute/dig/aws/config/AwsConfig.scala
@@ -10,6 +10,7 @@ import scala.util.Try
 
 /** AWS configuration settings. */
 final case class AwsConfig(
+  project: String,
   input: S3Config,
   output: S3Config,
   bioindex: S3Config,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.3-SNAPSHOT"
+version in ThisBuild := "0.3.4-SNAPSHOT"


### PR DESCRIPTION
Will allow for multiple projects to use the same runs db, but also to identify which stage run belongs to specific project.